### PR TITLE
Add AWS CodeBuild

### DIFF
--- a/msbuild/detect-ci-builds-for-every-ci-system.md
+++ b/msbuild/detect-ci-builds-for-every-ci-system.md
@@ -12,7 +12,8 @@ In order to unify the environment variable to detect whether a build is a CI bui
                  '$(BuildRunner)' == 'MyGet' or 
                  '$(JENKINS_URL)' != '' or 
                  '$(TRAVIS)' == 'true' or 
-                 '$(BUDDY)' == 'true'">true</CI>
+                 '$(BUDDY)' == 'true' or
+                 '$(CODEBUILD_CI)' == 'true'">true</CI>
 </PropertyGroup>
 ```
 


### PR DESCRIPTION
AWS CodeBuild appears to set a variable named `CODEBUILD_CI=true` , although it doesn't appear in [their docs](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html).  [Others use](https://github.com/GitTools/GitVersion/issues/1771) [it though](https://beerandserversdontmix.com/2021/05/20/build-system-integration-with-environment-variables/).